### PR TITLE
feature/sc-37570/update-verison-to-version-for-golangci-lint

### DIFF
--- a/src/jobs/lint.yml
+++ b/src/jobs/lint.yml
@@ -58,7 +58,7 @@ steps:
         - run:
             name: Verify Golangci-lint Install
             command: |-
-              golangci-lint verison
+              golangci-lint version
         - run:
             name: Lint Golang Application
             command: |-


### PR DESCRIPTION
Fixed typo "verison" to "version" in golang lint command. Found when having to update the config.yml of hierarchy service. 